### PR TITLE
Add Jest test for getRandomPosition helper

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+export default {
+  testEnvironment: 'jsdom',
+};

--- a/src/components/Home/Spotlight/utils/helpers.test.js
+++ b/src/components/Home/Spotlight/utils/helpers.test.js
@@ -1,0 +1,50 @@
+import { getRandomPosition } from './helpers.js';
+import { CARD_DIMENSIONS } from './constants.js';
+
+describe('getRandomPosition', () => {
+  test('returned x and y are within bounds for board size', () => {
+    const boardW = 800;
+    const boardH = 600;
+    const iterations = 20;
+    const cardW = CARD_DIMENSIONS.width;
+    const cardH = CARD_DIMENSIONS.height;
+
+    const minX = 10;
+    const maxX = boardW - cardW - 80;
+    const minY = 0;
+    const maxY = boardH - cardH - 100;
+    const safeMaxX = Math.max(minX + 10, maxX);
+    const safeMaxY = Math.max(minY + 10, maxY);
+
+    for (let i = 0; i < iterations; i++) {
+      const { x, y } = getRandomPosition(boardW, boardH);
+      expect(x).toBeGreaterThanOrEqual(minX);
+      expect(x).toBeLessThanOrEqual(safeMaxX);
+      expect(y).toBeGreaterThanOrEqual(minY);
+      expect(y).toBeLessThanOrEqual(safeMaxY);
+    }
+  });
+
+  test('respects custom card dimensions', () => {
+    const boardW = 500;
+    const boardH = 400;
+    const cardW = 100;
+    const cardH = 50;
+    const iterations = 20;
+
+    const minX = 10;
+    const maxX = boardW - cardW - 80;
+    const minY = 0;
+    const maxY = boardH - cardH - 100;
+    const safeMaxX = Math.max(minX + 10, maxX);
+    const safeMaxY = Math.max(minY + 10, maxY);
+
+    for (let i = 0; i < iterations; i++) {
+      const { x, y } = getRandomPosition(boardW, boardH, cardW, cardH);
+      expect(x).toBeGreaterThanOrEqual(minX);
+      expect(x).toBeLessThanOrEqual(safeMaxX);
+      expect(y).toBeGreaterThanOrEqual(minY);
+      expect(y).toBeLessThanOrEqual(safeMaxY);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- configure Jest environment
- add unit tests for `getRandomPosition` verifying bounds and custom card sizes

## Testing
- `NODE_OPTIONS=--experimental-vm-modules npx -y --package=jest --package=jest-environment-jsdom jest`

------
https://chatgpt.com/codex/tasks/task_e_68459c9e68f4832bbfa36dfd846d4fa0