### PR TITLE
Add root ESLint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,19 @@
+import config from './my-react-app/eslint.config.js';
+
+function trimGlobals(globalsObj = {}) {
+  return Object.fromEntries(
+    Object.entries(globalsObj).map(([k, v]) => [k.trim(), v])
+  );
+}
+
+export default config.map((entry) =>
+  entry.languageOptions && entry.languageOptions.globals
+    ? {
+        ...entry,
+        languageOptions: {
+          ...entry.languageOptions,
+          globals: trimGlobals(entry.languageOptions.globals),
+        },
+      }
+    : entry
+);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
+    "lint": "node node_modules/eslint/bin/eslint.js . --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- provide a root `eslint.config.js` that forwards the React app config
- use the local ESLint binary in the lint script

## Testing
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_68459ddec72c832b844f023c5249a81d