### PR TITLE
Add board page with carousel

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,7 @@ import RecipeLibrary from './components/Recipe/RecipeLibrary';
 import Blog from './components/Blog/Blog';
 import About from './components/About/About';
 import Subscribe from './components/Home/Subscribe';
+import BoardPage from './components/Board/BoardPage';
 import styled from 'styled-components';
 import NotFound from './components/NotFound/NotFound';
 
@@ -166,6 +167,7 @@ function App() {
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/recipes" element={<RecipeLibrary />} />
+          <Route path="/board" element={<BoardPage />} />
           <Route path="/blog" element={<Blog />} />
           <Route path="/about" element={<About />} />
           <Route path="/subscribe" element={<Subscribe />} />

--- a/src/components/Board/BoardPage.jsx
+++ b/src/components/Board/BoardPage.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import Spotlight from '../Home/Spotlight/Index';
+
+function BoardPage() {
+  return <Spotlight />;
+}
+
+export default BoardPage;

--- a/src/components/Home/Home.jsx
+++ b/src/components/Home/Home.jsx
@@ -1,121 +1,16 @@
-// Part of src/components/Home/Home.jsx - Mission Section
 import React from 'react';
-import styled from 'styled-components';
+import Hero from './Hero';
+import MissionSection from './MissionSection';
+import ImageCarousel from '../common/ImageCarousel';
 
-const Mission = styled.section`
-  background: var(--white);
-  padding: 5rem 2.5rem;
-  text-align: center;
-  margin: 5rem auto 3rem;
-  max-width: 1200px;
-  border-radius: var(--radius-standard);
-  box-shadow: var(--shadow-soft);
-  
-  &[data-observe] {
-    opacity: 0;
-    transform: translateY(30px);
-    transition: opacity 0.9s, transform 0.9s;
-  }
-  
-  &.visible {
-    opacity: 1;
-    transform: translateY(0);
-  }
-`;
-
-const MissionTitle = styled.h2`
-  margin-bottom: 2rem;
-  color: var(--accent);
-`;
-
-const MissionStatement = styled.p`
-  font-size: 1.3rem;
-  max-width: 800px;
-  margin: 0 auto 3rem;
-  line-height: 1.8;
-  color: var(--text-medium);
-`;
-
-const Values = styled.div`
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: 2rem;
-  margin-top: 3rem;
-`;
-
-const ValueCard = styled.div`
-  padding: 2rem;
-  background: var(--linen);
-  border-radius: 0.5rem;
-  transition: transform 0.3s;
-  
-  &:hover {
-    transform: translateY(-5px);
-  }
-`;
-
-const ValueIcon = styled.div`
-  font-size: 2.5rem;
-  margin-bottom: 1rem;
-`;
-
-const ValueTitle = styled.h3`
-  color: var(--accent);
-  margin-bottom: 1rem;
-`;
-
-const ValueText = styled.p`
-  color: var(--text-medium);
-  line-height: 1.6;
-`;
-
-// Component Usage:
-function MissionSection() {
+function Home() {
   return (
-    <Mission id="mission" data-observe>
-      <MissionTitle>Our Philosophy</MissionTitle>
-      <MissionStatement>
-        At Sal, we believe exceptional bread is worth the wait. Our mission is to craft 
-        focaccia that brings people together, using time-honored techniques and the 
-        finest organic ingredients to create something truly special.
-      </MissionStatement>
-      
-      <Values>
-        <ValueCard>
-          <ValueIcon>🌾</ValueIcon>
-          <ValueTitle>Quality First</ValueTitle>
-          <ValueText>
-            Only the best organic flour, premium olive oil, and locally-sourced 
-            ingredients make it into our focaccia.
-          </ValueText>
-        </ValueCard>
-        <ValueCard>
-          <ValueIcon>⏰</ValueIcon>
-          <ValueTitle>Time & Patience</ValueTitle>
-          <ValueText>
-            48-hour fermentation isn't just a process—it's our commitment to 
-            developing complex flavors and perfect texture.
-          </ValueText>
-        </ValueCard>
-        <ValueCard>
-          <ValueIcon>🤝</ValueIcon>
-          <ValueTitle>Community</ValueTitle>
-          <ValueText>
-            From local farmers to your dinner table, we're proud to be part of 
-            Central Illinois' vibrant food community.
-          </ValueText>
-        </ValueCard>
-        <ValueCard>
-          <ValueIcon>✨</ValueIcon>
-          <ValueTitle>Artisan Craft</ValueTitle>
-          <ValueText>
-            Every loaf is shaped by hand, dimpled with care, and baked to 
-            golden perfection—no shortcuts, ever.
-          </ValueText>
-        </ValueCard>
-      </Values>
-    </Mission>
+    <>
+      <Hero />
+      <ImageCarousel />
+      <MissionSection />
+    </>
   );
 }
 
-export default MissionSection;
+export default Home;

--- a/src/components/Home/MissionSection.jsx
+++ b/src/components/Home/MissionSection.jsx
@@ -1,0 +1,121 @@
+// Part of src/components/Home/Home.jsx - Mission Section
+import React from 'react';
+import styled from 'styled-components';
+
+const Mission = styled.section`
+  background: var(--white);
+  padding: 5rem 2.5rem;
+  text-align: center;
+  margin: 5rem auto 3rem;
+  max-width: 1200px;
+  border-radius: var(--radius-standard);
+  box-shadow: var(--shadow-soft);
+  
+  &[data-observe] {
+    opacity: 0;
+    transform: translateY(30px);
+    transition: opacity 0.9s, transform 0.9s;
+  }
+  
+  &.visible {
+    opacity: 1;
+    transform: translateY(0);
+  }
+`;
+
+const MissionTitle = styled.h2`
+  margin-bottom: 2rem;
+  color: var(--accent);
+`;
+
+const MissionStatement = styled.p`
+  font-size: 1.3rem;
+  max-width: 800px;
+  margin: 0 auto 3rem;
+  line-height: 1.8;
+  color: var(--text-medium);
+`;
+
+const Values = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 2rem;
+  margin-top: 3rem;
+`;
+
+const ValueCard = styled.div`
+  padding: 2rem;
+  background: var(--linen);
+  border-radius: 0.5rem;
+  transition: transform 0.3s;
+  
+  &:hover {
+    transform: translateY(-5px);
+  }
+`;
+
+const ValueIcon = styled.div`
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+`;
+
+const ValueTitle = styled.h3`
+  color: var(--accent);
+  margin-bottom: 1rem;
+`;
+
+const ValueText = styled.p`
+  color: var(--text-medium);
+  line-height: 1.6;
+`;
+
+// Component Usage:
+function MissionSection() {
+  return (
+    <Mission id="mission" data-observe>
+      <MissionTitle>Our Philosophy</MissionTitle>
+      <MissionStatement>
+        At Sal, we believe exceptional bread is worth the wait. Our mission is to craft 
+        focaccia that brings people together, using time-honored techniques and the 
+        finest organic ingredients to create something truly special.
+      </MissionStatement>
+      
+      <Values>
+        <ValueCard>
+          <ValueIcon>🌾</ValueIcon>
+          <ValueTitle>Quality First</ValueTitle>
+          <ValueText>
+            Only the best organic flour, premium olive oil, and locally-sourced 
+            ingredients make it into our focaccia.
+          </ValueText>
+        </ValueCard>
+        <ValueCard>
+          <ValueIcon>⏰</ValueIcon>
+          <ValueTitle>Time & Patience</ValueTitle>
+          <ValueText>
+            48-hour fermentation isn't just a process—it's our commitment to 
+            developing complex flavors and perfect texture.
+          </ValueText>
+        </ValueCard>
+        <ValueCard>
+          <ValueIcon>🤝</ValueIcon>
+          <ValueTitle>Community</ValueTitle>
+          <ValueText>
+            From local farmers to your dinner table, we're proud to be part of 
+            Central Illinois' vibrant food community.
+          </ValueText>
+        </ValueCard>
+        <ValueCard>
+          <ValueIcon>✨</ValueIcon>
+          <ValueTitle>Artisan Craft</ValueTitle>
+          <ValueText>
+            Every loaf is shaped by hand, dimpled with care, and baked to 
+            golden perfection—no shortcuts, ever.
+          </ValueText>
+        </ValueCard>
+      </Values>
+    </Mission>
+  );
+}
+
+export default MissionSection;

--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -108,7 +108,7 @@ function Header() {
       </LogoContainer>
       <Nav>
         <NavLink to="/" $isHome={isHomePage} $scrolled={scrolled}>Home</NavLink>
-        <NavLink to="/#spotlight" $isHome={isHomePage} $scrolled={scrolled}>Collection</NavLink>
+        <NavLink to="/board" $isHome={isHomePage} $scrolled={scrolled}>Board</NavLink>
         <NavLink to="/recipes" $isHome={isHomePage} $scrolled={scrolled}>Menu</NavLink>
         <NavLink to="/blog" $isHome={isHomePage} $scrolled={scrolled}>Blog</NavLink>
         <NavLink to="/about" $isHome={isHomePage} $scrolled={scrolled}>Our Story</NavLink>

--- a/src/components/common/ImageCarousel.jsx
+++ b/src/components/common/ImageCarousel.jsx
@@ -1,0 +1,85 @@
+import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
+import logo from '../../assets/logo.svg';
+import reactLogo from '../../assets/react.svg';
+
+const CarouselWrapper = styled.div`
+  position: relative;
+  width: 100%;
+  max-width: 600px;
+  margin: 3rem auto;
+  overflow: hidden;
+`;
+
+const Slides = styled.div`
+  display: flex;
+  transition: transform 0.5s ease;
+  transform: translateX(${props => props.$index * -100}%);
+`;
+
+const Slide = styled.div`
+  flex: 0 0 100%;
+  display: flex;
+  justify-content: center;
+`;
+
+const Img = styled.img`
+  width: 100%;
+  height: auto;
+`;
+
+const Controls = styled.div`
+  position: absolute;
+  top: 50%;
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  transform: translateY(-50%);
+`;
+
+const Button = styled.button`
+  background: rgba(0,0,0,0.5);
+  border: none;
+  color: white;
+  font-size: 1.5rem;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+`;
+
+function ImageCarousel() {
+  const images = [logo, reactLogo];
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setIndex(i => (i + 1) % images.length);
+    }, 3000);
+    return () => clearInterval(id);
+  }, [images.length]);
+
+  const prev = () => {
+    setIndex(i => (i - 1 + images.length) % images.length);
+  };
+
+  const next = () => {
+    setIndex(i => (i + 1) % images.length);
+  };
+
+  return (
+    <CarouselWrapper>
+      <Slides $index={index}>
+        {images.map((src, i) => (
+          <Slide key={i}>
+            <Img src={src} alt="slide" />
+          </Slide>
+        ))}
+      </Slides>
+      <Controls>
+        <Button onClick={prev} aria-label="Previous">‹</Button>
+        <Button onClick={next} aria-label="Next">›</Button>
+      </Controls>
+    </CarouselWrapper>
+  );
+}
+
+export default ImageCarousel;


### PR DESCRIPTION
## Summary
- move mission code to `MissionSection` component
- create new `Home` page with hero, carousel and mission
- add simple image carousel component
- add Board page route and navigation link

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68472650e570832b8fb375237b388d0b